### PR TITLE
Adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
 node_js:
-  - '0.10'
   - '4'
-  - '6'
-sudo: false

--- a/lib/readable.js
+++ b/lib/readable.js
@@ -64,7 +64,7 @@ function readable(options) {
 
   function makeRequest(request) {
     pending = true;
-
+    if (!request.on) console.log(request);
     request
       .on('error', function(err) { logStream.emit('error', err); })
       .on('retry', options.retry)

--- a/lib/readable.js
+++ b/lib/readable.js
@@ -52,7 +52,7 @@ function readable(options) {
   var params = {
     logGroupName: options.group,
     endTime: options.end,
-    filterPattern: options.pattern,
+    filterPattern: '"' + options.pattern + '"',
     interleaved: true,
     startTime: options.start
   };
@@ -74,7 +74,8 @@ function readable(options) {
 
         for (var i = 0; i < response.data.events.length; i++) {
           var item = options.messages ?
-            response.data.events[i].message : response.data.events[i];
+            response.data.events[i].message.trim() + '\n' : response.data.events[i];
+
           events.push(item);
         }
 

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/mapbox/cwlogs#readme",
   "devDependencies": {
-    "aws-sdk-mock": "^1.2.0",
-    "documentation": "^4.0.0-beta5",
-    "eslint": "^2.11.1",
-    "nyc": "^6.4.4",
+    "aws-sdk-mock": "1.2.0",
+    "documentation": "^4.0.0-beta9",
+    "eslint": "^3.1.1",
+    "nyc": "^7.1.0",
     "opener": "^1.4.1",
-    "tape": "^4.5.1"
+    "tape": "^4.6.0"
   },
   "dependencies": {
     "aws-sdk": "^2.3.17",

--- a/test/readable.test.js
+++ b/test/readable.test.js
@@ -138,7 +138,7 @@ test('[readable] messages strips object wrappers', function(assert) {
         assert.pass('finished without error');
         assert.equal(writer.chunks.length, 1000, 'got all events');
         assert.ok(writer.chunks.every(function(chunk, i) {
-          return chunk.toString() === i.toString();
+          return chunk.toString() === i.toString() + '\n';
         }), 'only returned .message for each event');
         AWS.restore('CloudWatchLogs');
         assert.end();


### PR DESCRIPTION
- makes `messages` output line-delimited
- adjusts filter pattern to be literal -- log filtering syntax is ridiculous
