### PR TITLE
added profile option.

### DIFF
--- a/lib/readable.js
+++ b/lib/readable.js
@@ -42,6 +42,11 @@ function readable(options) {
   if (options.pattern && typeof options.pattern !== 'string') return invalid();
   if (options.retry && typeof options.retry !== 'function') return invalid();
   if (options.messages && typeof options.messages !== 'boolean') return invalid();
+  if (options.profile && typeof options.profile !== 'string') return invalid();
+
+  if (options.profile) {
+    AWS.config.credentials = new AWS.SharedIniFileCredentials({profile: options.profile});
+  }
 
   options.objectMode = !options.messages;
   options.start = options.start || Date.now() - 15 * 60 * 1000;


### PR DESCRIPTION
This way we can define which profile to use when reading logs from Amazon. 

the given profile name  should exists in ~/.aws/credentials file.

